### PR TITLE
Append newline to configure.ac.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,3 +126,4 @@ AC_CONFIG_FILES(Makefile
                 docs/Makefile)
 AC_CONFIG_HEADERS(config.h)
 AC_OUTPUT
+


### PR DESCRIPTION
Append newline in configure.ac to avoid autoreconf failing with:
        INTERNAL ERROR: recursive push_string

Tested on Mac OS  X 10.10 and NetBSD 7.99.5 amd64.
