### PR TITLE
Use xmalloc0 instead of xmalloc in asignify_private_data_sign.

### DIFF
--- a/libasignify/signature.c
+++ b/libasignify/signature.c
@@ -128,7 +128,7 @@ asignify_private_data_sign(struct asignify_private_data *privk,
 	unsigned long long outlen = len;
 
 	if (buf != NULL && len > 0 && privk != NULL) {
-		res = xmalloc(sizeof(*res));
+		res = xmalloc0(sizeof(*res));
 		res->version = privk->version;
 		res->id_len = privk->id_len;
 		res->data_len = crypto_sign_BYTES;


### PR DESCRIPTION
`asignify_alloc_public_data_fields` later on checks whether its `aux_len` is set, which can be the case when not zeroing its contents first.

Not using `xmalloc0` may crash the program when signing.

There **may** be more cases, but for now the tool works again.