### PR TITLE
libasignify: use xmalloc0 for initializing public key data

### DIFF
--- a/libasignify/pubkey.c
+++ b/libasignify/pubkey.c
@@ -63,7 +63,7 @@ asignify_pubkey_try_obsd(const char *buf, size_t buflen,
 
 	if (b64_pton(buf, (unsigned char *)&opk, sizeof(opk)) == sizeof(opk)) {
 		if (memcmp(opk.pkalg, OBSD_PKALG, sizeof(opk.pkalg)) == 0) {
-			res = xmalloc(sizeof(*res));
+			res = xmalloc0(sizeof(*res));
 			/* OpenBSD version code */
 			res->version = 0;
 			res->data_len = sizeof(opk.pubkey);

--- a/libasignify/signature.c
+++ b/libasignify/signature.c
@@ -66,7 +66,7 @@ asignify_sig_try_obsd(const char *buf, size_t buflen,
 
 	if (b64_pton(buf, (unsigned char *)&osig, sizeof(osig)) == sizeof(osig)) {
 		if (memcmp(osig.sigalg, OBSD_SIGALG, sizeof(osig.sigalg)) == 0) {
-			res = xmalloc(sizeof(*res));
+			res = xmalloc0(sizeof(*res));
 			/* OpenBSD version code */
 			res->version = 0;
 			res->data_len = sizeof(osig.sig);


### PR DESCRIPTION
These paths read OpenBSD signatures and don't currently initialize
all of the fields they need to; fix and future-proof them with xmalloc0.

This manifested as a segfault when the verification path went to free
pubkey data from an OpenBSD signature.