### PR TITLE
libasignify: databuf: drop spurious explicit_memzero

### DIFF
--- a/libasignify/databuf.c
+++ b/libasignify/databuf.c
@@ -466,7 +466,6 @@ asignify_private_data_unpack_key(struct asignify_private_key *privk, int *error,
 			sizeof(xorkey), 0);
 
 		if (memcmp(res_checksum, privk->checksum, sizeof(res_checksum)) != 0) {
-			explicit_memzero(privk->encrypted_blob, crypto_sign_SECRETKEYBYTES);
 			asignify_privkey_cleanup(privk);
 			free(priv);
 


### PR DESCRIPTION
The immediately following asignify_privkey_cleanup() will take care of
this, which must be relied upon to take care of it elsewhere.