### PR TITLE
Mass-reflow of libasignify

### DIFF
--- a/include/asignify.h
+++ b/include/asignify.h
@@ -161,7 +161,7 @@ void asignify_sign_free(asignify_sign_t *ctx);
  * @param privkf filename for private key
  * @param pubkf filename for public key
  * @param version version of pair
- * @param rounds rounds of PBKDF
+ * @param rounds rounds of PBKDF (if 0 then private key is not encrypted)
  * @param password_cb password callback (if NULL then private key is not encrypted)
  * @param d opaque data pointer for password
  * @return true if pair has been written successfully

--- a/libasignify/asignify_internal.h
+++ b/libasignify/asignify_internal.h
@@ -47,6 +47,10 @@
 #define STRUCT_MEMBER_PTR(member_type, struct_p, struct_offset)   \
     ((member_type*)((void *)((unsigned char*)(struct_p) + (long)(struct_offset))))
 
+#ifndef nitems
+#define	nitems(x)	(sizeof((x)) / sizeof((x)[0]))
+#endif
+
 struct asignify_public_data {
 	unsigned char *data;
 	size_t data_len;

--- a/libasignify/databuf.c
+++ b/libasignify/databuf.c
@@ -144,7 +144,7 @@ asignify_public_data_load(const char *buf, size_t buflen, const char *magic,
 	char *errstr;
 	const char *p = buf;
 	unsigned int version;
-	size_t remain = buflen, blen;
+	size_t blen;
 	struct asignify_public_data *res = NULL;
 
 	if (buflen <= magiclen || memcmp (buf, magic, magiclen) != 0) {
@@ -152,7 +152,6 @@ asignify_public_data_load(const char *buf, size_t buflen, const char *magic,
 	}
 
 	p += magiclen;
-	remain -= magiclen;
 
 	version = strtoul(p, &errstr, 10);
 	if (errstr == NULL || *errstr != ':'

--- a/libasignify/databuf.c
+++ b/libasignify/databuf.c
@@ -182,15 +182,17 @@ asignify_public_data_load(const char *buf, size_t buflen, const char *magic,
 		return (NULL);
 	}
 
-	if ((p = strchr(p, ':')) != NULL) {
-		/* We have some aux data for this line */
-		p ++;
-		res->aux_len = strcspn(p, "\n\r");
-		if (res->aux_len > 0) {
-			res->aux = xmalloc(res->aux_len + 1);
-			memcpy(res->aux, p, res->aux_len);
-			res->aux[res->aux_len] = '\0';
-		}
+	if ((p = strchr(p, ':')) == NULL) {
+		return (res);
+	}
+
+	/* We have some aux data for this line */
+	p ++;
+	res->aux_len = strcspn(p, "\n\r");
+	if (res->aux_len > 0) {
+		res->aux = xmalloc(res->aux_len + 1);
+		memcpy(res->aux, p, res->aux_len);
+		res->aux[res->aux_len] = '\0';
 	}
 
 	return (res);
@@ -214,17 +216,19 @@ asignify_parser_fields_cmp(const void *k, const void *st)
 static void
 asignify_privkey_cleanup(struct asignify_private_key *privk)
 {
-	if (privk != NULL) {
-		free(privk->checksum);
-		if (privk->encrypted_blob) {
-			explicit_memzero(privk->encrypted_blob, crypto_sign_SECRETKEYBYTES);
-		}
-		free(privk->encrypted_blob);
-		free(privk->id);
-		free(privk->pbkdf_alg);
-		free(privk->salt);
-		explicit_memzero(privk, sizeof(*privk));
+	if (privk == NULL) {
+		return;
 	}
+
+	free(privk->checksum);
+	if (privk->encrypted_blob) {
+		explicit_memzero(privk->encrypted_blob, crypto_sign_SECRETKEYBYTES);
+	}
+	free(privk->encrypted_blob);
+	free(privk->id);
+	free(privk->pbkdf_alg);
+	free(privk->salt);
+	explicit_memzero(privk, sizeof(*privk));
 }
 
 static bool
@@ -372,28 +376,20 @@ asignify_private_data_parse_line(const char *buf, size_t buflen,
 static bool
 asignify_private_key_is_sane(struct asignify_private_key *privk)
 {
-	if (privk->pbkdf_alg && strcmp(privk->pbkdf_alg, PBKDF_ALG) == 0) {
-		if (privk->rounds >= PBKDF_MINROUNDS) {
-			if (privk->salt) {
-				if (privk->version == 1) {
-					if (privk->encrypted_blob != NULL &&
-									privk->checksum != NULL) {
-						return (true);
-					}
-				}
-			}
-		}
-	}
-	else {
+	if (!privk->pbkdf_alg || strcmp(privk->pbkdf_alg, PBKDF_ALG) != 0) {
 		/* Unencrypted key */
-		if (privk->version == 1) {
-			if (privk->encrypted_blob != NULL) {
-				return (true);
-			}
-		}
+		return (privk->version == 1 && privk->encrypted_blob != NULL);
 	}
 
-	return (false);
+	if (privk->rounds < PBKDF_MINROUNDS) {
+		return (false);
+	}
+
+	if (privk->salt == NULL || privk->version != 1) {
+		return (false);
+	}
+
+	return (privk->encrypted_blob != NULL && privk->checksum != NULL);
 }
 
 static void
@@ -423,66 +419,62 @@ asignify_private_data_unpack_key(struct asignify_private_key *privk, int *error,
 	unsigned char xorkey[crypto_sign_SECRETKEYBYTES];
 	unsigned char res_checksum[BLAKE2B_OUTBYTES];
 	int r;
+	bool ok = false;
 
 	priv = xmalloc(sizeof(*priv));
-
-	if (privk->pbkdf_alg) {
-		/* We need to derive key */
-		if (password_cb == NULL) {
-			free(priv);
-			asignify_privkey_cleanup(privk);
-			return (NULL);
-		}
-
-		/* Some buffer overflow protection */
-		randombytes(canary, sizeof(canary));
-		memcpy(password + sizeof(password) - sizeof(canary), canary,
-				sizeof(canary));
-		r = password_cb(password, sizeof(password) - sizeof(canary), d);
-		if (r <= 0 || r > sizeof(password) - sizeof(canary) ||
-			memcmp(password + sizeof(password) - sizeof(canary), canary, sizeof(canary)) != 0) {
-			free(priv);
-			explicit_memzero(password, sizeof(password));
-			asignify_privkey_cleanup(privk);
-			return (NULL);
-		}
-
-		if (pkcs5_pbkdf2(password, r, privk->salt, SALT_LEN, xorkey, sizeof(xorkey),
-			privk->rounds) == -1) {
-			free(priv);
-			explicit_memzero(password, sizeof(password));
-			asignify_privkey_cleanup(privk);
-			return (NULL);
-		}
-		explicit_memzero(password, sizeof(password));
-
-		for (r = 0; r < sizeof(xorkey); r ++) {
-			privk->encrypted_blob[r] ^= xorkey[r];
-		}
-
-		explicit_memzero(xorkey, sizeof(xorkey));
-		blake2b(res_checksum, privk->encrypted_blob, NULL, BLAKE2B_OUTBYTES,
-			sizeof(xorkey), 0);
-
-		if (memcmp(res_checksum, privk->checksum, sizeof(res_checksum)) != 0) {
-			explicit_memzero(privk->encrypted_blob, crypto_sign_SECRETKEYBYTES);
-			asignify_privkey_cleanup(privk);
-			free(priv);
-
-			if (error != NULL) {
-				*error = ASIGNIFY_ERROR_PASSWORD;
-			}
-
-			return (NULL);
-		}
-		asignify_pkey_to_private_data(privk, priv);
-	}
-	else {
-		asignify_pkey_to_private_data(privk, priv);
+	if (privk->pbkdf_alg == NULL) {
+		goto done;
 	}
 
+	/* We need to derive key */
+	if (password_cb == NULL) {
+		goto cleanup;
+	}
+
+	/* Some buffer overflow protection */
+	randombytes(canary, sizeof(canary));
+	memcpy(password + sizeof(password) - sizeof(canary), canary,
+			sizeof(canary));
+	r = password_cb(password, sizeof(password) - sizeof(canary), d);
+	if (r <= 0 || r > sizeof(password) - sizeof(canary) ||
+		memcmp(password + sizeof(password) - sizeof(canary), canary, sizeof(canary)) != 0) {
+		goto cleanup;
+	}
+
+	if (pkcs5_pbkdf2(password, r, privk->salt, SALT_LEN, xorkey, sizeof(xorkey),
+		privk->rounds) == -1) {
+		goto cleanup;
+	}
+
+	explicit_memzero(password, sizeof(password));
+
+	for (r = 0; r < sizeof(xorkey); r ++) {
+		privk->encrypted_blob[r] ^= xorkey[r];
+	}
+
+	explicit_memzero(xorkey, sizeof(xorkey));
+	blake2b(res_checksum, privk->encrypted_blob, NULL, BLAKE2B_OUTBYTES,
+		sizeof(xorkey), 0);
+
+	if (memcmp(res_checksum, privk->checksum, sizeof(res_checksum)) != 0) {
+		if (error != NULL) {
+			*error = ASIGNIFY_ERROR_PASSWORD;
+		}
+
+		goto cleanup;
+	}
+
+done:
+	ok = true;
+	asignify_pkey_to_private_data(privk, priv);
+
+cleanup:
+	explicit_memzero(password, sizeof(password));
 	asignify_privkey_cleanup(privk);
-
+	if (!ok) {
+		free(priv);
+		priv = NULL;
+	}
 	return (priv);
 }
 
@@ -492,51 +484,55 @@ asignify_private_data_load(FILE *f, int *error,
 {
 	char *buf = NULL;
 	size_t buflen = 0;
+	struct asignify_private_data *pkeyd;
 	struct asignify_private_key privk;
 	bool first = true;
 	ssize_t r;
 
 	memset(&privk, 0, sizeof(privk));
+	pkeyd = NULL;
 
 	while ((r = getline(&buf, &buflen, f)) != -1) {
 		if (first) {
 			/* Check magic */
-			if (memcmp(buf, PRIVKEY_MAGIC, sizeof(PRIVKEY_MAGIC) - 1) == 0) {
-				first = false;
-			}
-			else {
+			if (memcmp(buf, PRIVKEY_MAGIC, sizeof(PRIVKEY_MAGIC) - 1) != 0) {
 				return (NULL);
 			}
+
+			first = false;
+			continue;
 		}
-		else {
-			if (!asignify_private_data_parse_line(buf, r, &privk)) {
-				asignify_privkey_cleanup(&privk);
-				return (NULL);
-			}
+
+		if (!asignify_private_data_parse_line(buf, r, &privk)) {
+			goto cleanup;
 		}
 	}
 
 	if (!asignify_private_key_is_sane(&privk)) {
-		asignify_privkey_cleanup(&privk);
-		return (NULL);
+		goto cleanup;
 	}
 
-	return (asignify_private_data_unpack_key(&privk, error, password_cb, d));
+	pkeyd = asignify_private_data_unpack_key(&privk, error, password_cb, d);
+cleanup:
+	asignify_privkey_cleanup(&privk);
+	return (pkeyd);
 }
 
 void
 asignify_private_data_free(struct asignify_private_data *d)
 {
-	if (d != NULL) {
-		free(d->id);
-		d->id = NULL;
-		explicit_memzero(d->data, d->data_len);
-#ifdef HAVE_MLOCK
-		munlock(d->data, d->data_len);
-#endif
-		free(d->data);
-		free(d);
+	if (d == NULL) {
+		return;
 	}
+
+	free(d->id);
+	d->id = NULL;
+	explicit_memzero(d->data, d->data_len);
+#ifdef HAVE_MLOCK
+	munlock(d->data, d->data_len);
+#endif
+	free(d->data);
+	free(d);
 }
 
 const unsigned char *

--- a/libasignify/generate.c
+++ b/libasignify/generate.c
@@ -49,6 +49,7 @@ asignify_encrypt_privkey(struct asignify_private_key *privk, unsigned int rounds
 	unsigned char xorkey[crypto_sign_SECRETKEYBYTES];
 	char password[1024];
 	int r;
+	bool ret = false;
 
 	privk->checksum = xmalloc(BLAKE2B_OUTBYTES);
 	privk->salt = xmalloc(SALT_LEN);
@@ -64,12 +65,12 @@ asignify_encrypt_privkey(struct asignify_private_key *privk, unsigned int rounds
 	r = password_cb(password, sizeof(password) - sizeof(canary), d);
 	if (r <= 0 || r > sizeof(password) - sizeof(canary) ||
 			memcmp(password + sizeof(password) - sizeof(canary), canary, sizeof(canary)) != 0) {
-		return (false);
+		goto cleanup;
 	}
 
 	if (pkcs5_pbkdf2(password, r, privk->salt, SALT_LEN, xorkey, sizeof(xorkey),
 			privk->rounds) == -1) {
-		return (false);
+		goto cleanup;
 	}
 
 	explicit_memzero(password, sizeof(password));
@@ -79,8 +80,15 @@ asignify_encrypt_privkey(struct asignify_private_key *privk, unsigned int rounds
 	}
 
 	explicit_memzero(xorkey, sizeof(xorkey));
-
-	return (true);
+	ret = true;
+cleanup:
+	if (!ret) {
+		free(privk->salt);
+		privk->salt = NULL;
+		free(privk->checksum);
+		privk->checksum = NULL;
+	}
+	return (ret);
 }
 
 static bool
@@ -90,7 +98,7 @@ asignify_generate_v1(FILE *privf, FILE *pubf, unsigned int rounds,
 
 	struct asignify_private_key *privk;
 	struct asignify_public_data *pubk;
-	bool ret = true;
+	bool ret = false;
 
 	if (privf == NULL || pubf == NULL ||
 			(password_cb != NULL && rounds < PBKDF_MINROUNDS)) {
@@ -101,16 +109,17 @@ asignify_generate_v1(FILE *privf, FILE *pubf, unsigned int rounds,
 	pubk = xmalloc0(sizeof(*pubk));
 
 	privk->version = 1;
-	pubk->version = 1;
 	privk->id = xmalloc(KEY_ID_LEN);
-	pubk->id = xmalloc(KEY_ID_LEN);
-	pubk->id_len = KEY_ID_LEN;
 	randombytes(privk->id, KEY_ID_LEN);
+
+	pubk->version = 1;
+	pubk->data_len = crypto_sign_PUBLICKEYBYTES;
+	pubk->id_len = KEY_ID_LEN;
+	asignify_alloc_public_data_fields(pubk);
+
 	memcpy(pubk->id, privk->id, KEY_ID_LEN);
 
 	privk->encrypted_blob = xmalloc(crypto_sign_SECRETKEYBYTES);
-	pubk->data = xmalloc(crypto_sign_PUBLICKEYBYTES);
-	pubk->data_len = crypto_sign_PUBLICKEYBYTES;
 	crypto_sign_keypair(pubk->data, privk->encrypted_blob);
 
 	if (password_cb != NULL) {
@@ -126,14 +135,11 @@ asignify_generate_v1(FILE *privf, FILE *pubf, unsigned int rounds,
 
 cleanup:
 	asignify_public_data_free(pubk);
+
 	explicit_memzero(privk->encrypted_blob, crypto_sign_SECRETKEYBYTES);
-
-	free(privk->salt);
-	free(privk->checksum);
 	free(privk->encrypted_blob);
-
-	fclose(pubf);
-	fclose(privf);
+	free(privk->id);
+	free(privk);
 
 	return (ret);
 }
@@ -181,31 +187,31 @@ bool
 asignify_privkey_write(struct asignify_private_key *privk, FILE *f)
 {
 	char *hexdata;
-	bool ret = false;
 
 	if (privk == NULL || f == NULL) {
 		return (false);
 	}
 
-	if (privk->version == 1) {
-		fprintf(f, PRIVKEY_MAGIC "\n" "version: %u\n", privk->version);
-		HEX_OUT_PRIVK(privk, encrypted_blob, "data", crypto_sign_SECRETKEYBYTES, f);
-
-		if (privk->id) {
-			HEX_OUT_PRIVK(privk, id, "id", KEY_ID_LEN, f);
-		}
-
-		/* Encrypted privkey */
-		if (privk->pbkdf_alg != NULL) {
-			fprintf(f, "kdf: %s\n", privk->pbkdf_alg);
-			fprintf(f, "rounds: %u\n", privk->rounds);
-			HEX_OUT_PRIVK(privk, salt, "salt", SALT_LEN, f);
-			HEX_OUT_PRIVK(privk, checksum, "checksum", BLAKE2B_OUTBYTES, f);
-		}
-		ret = true;
+	if (privk->version != 1) {
+		return (false);
 	}
 
-	return (ret);
+	fprintf(f, PRIVKEY_MAGIC "\n" "version: %u\n", privk->version);
+	HEX_OUT_PRIVK(privk, encrypted_blob, "data", crypto_sign_SECRETKEYBYTES, f);
+
+	if (privk->id) {
+		HEX_OUT_PRIVK(privk, id, "id", KEY_ID_LEN, f);
+	}
+
+	/* Encrypted privkey */
+	if (privk->pbkdf_alg != NULL) {
+		fprintf(f, "kdf: %s\n", privk->pbkdf_alg);
+		fprintf(f, "rounds: %u\n", privk->rounds);
+		HEX_OUT_PRIVK(privk, salt, "salt", SALT_LEN, f);
+		HEX_OUT_PRIVK(privk, checksum, "checksum", BLAKE2B_OUTBYTES, f);
+	}
+
+	return (true);
 }
 
 bool
@@ -213,20 +219,25 @@ asignify_generate(const char *privkf, const char *pubkf, unsigned int version,
 		unsigned int rounds, asignify_password_cb password_cb, void *d)
 {
 	FILE *privf, *pubf;
+	bool ret = false;
 
+	if (version != 1)
+		return (false);
 
-	if (version == 1) {
-		privf = xfopen(privkf, "w");
-		pubf = xfopen(pubkf, "w");
+	privf = xfopen(privkf, "w");
+	pubf = xfopen(pubkf, "w");
 
-		if (!privf || !pubf) {
-			return (false);
-		}
-
-		return (asignify_generate_v1(privf, pubf, rounds, password_cb, d));
+	if (!privf || !pubf) {
+		goto cleanup;
 	}
 
-	return (false);
+	ret = asignify_generate_v1(privf, pubf, rounds, password_cb, d);
+cleanup:
+	if (pubf != NULL)
+		fclose(pubf);
+	if (privf != NULL)
+		fclose(privf);
+	return (ret);
 }
 
 bool
@@ -268,41 +279,45 @@ asignify_privkey_from_ssh(const char *sshkf, const char *privkf,
 	struct asignify_private_key privk;
 	bool ret = false;
 
-	if (version == 1) {
-		sshf = xfopen(sshkf, "r");
+	if (version != 1)
+		return (false);
 
-		if (!sshf) {
-			return (false);
-		}
+	privf = NULL;
+	sshf = xfopen(sshkf, "r");
 
-		privd = asignify_ssh_privkey_load(sshf, NULL);
-
-		if (privd == NULL) {
-			return (false);
-		}
-
-		privf = xfopen(privkf, "w");
-		if (privf == NULL) {
-			asignify_private_data_free(privd);
-			return (false);
-		}
-
-		memset(&privk, 0, sizeof(privk));
-		privk.encrypted_blob = privd->data;
-		privk.version = version;
-		privk.id = NULL;
-
-		if (password_cb != NULL) {
-			if (!asignify_encrypt_privkey(&privk, rounds, password_cb, d)) {
-				asignify_private_data_free(privd);
-				return (false);
-			}
-		}
-
-		ret = asignify_privkey_write(&privk, privf);
+	if (!sshf) {
+		return (false);
 	}
 
+	privd = asignify_ssh_privkey_load(sshf, NULL);
+	if (privd == NULL) {
+		goto cleanup;
+	}
+
+	privf = xfopen(privkf, "w");
+	if (privf == NULL) {
+		goto cleanup;
+	}
+
+	memset(&privk, 0, sizeof(privk));
+	privk.encrypted_blob = privd->data;
+	privk.version = version;
+	privk.id = NULL;
+
+	if (password_cb != NULL) {
+		if (!asignify_encrypt_privkey(&privk, rounds, password_cb, d)) {
+			goto cleanup;
+		}
+	}
+
+	ret = asignify_privkey_write(&privk, privf);
+
+cleanup:
 	asignify_private_data_free(privd);
+	if (sshf != NULL)
+		fclose(sshf);
+	if (privf != NULL)
+		fclose(privf);
 
 	return (ret);
 }

--- a/libasignify/generate.c
+++ b/libasignify/generate.c
@@ -100,8 +100,13 @@ asignify_generate_v1(FILE *privf, FILE *pubf, unsigned int rounds,
 	struct asignify_public_data *pubk;
 	bool ret = false;
 
-	if (privf == NULL || pubf == NULL ||
-			(password_cb != NULL && rounds < PBKDF_MINROUNDS)) {
+	if (privf == NULL || pubf == NULL) {
+		return (false);
+	}
+	if (rounds != 0 && password_cb == NULL) {
+		return (false);
+	}
+	if (rounds != 0 && rounds < PBKDF_MINROUNDS) {
 		return (false);
 	}
 
@@ -122,7 +127,7 @@ asignify_generate_v1(FILE *privf, FILE *pubf, unsigned int rounds,
 	privk->encrypted_blob = xmalloc(crypto_sign_SECRETKEYBYTES);
 	crypto_sign_keypair(pubk->data, privk->encrypted_blob);
 
-	if (password_cb != NULL) {
+	if (rounds > 0) {
 		if (!asignify_encrypt_privkey(privk, rounds, password_cb, d)) {
 			goto cleanup;
 		}

--- a/libasignify/sign.c
+++ b/libasignify/sign.c
@@ -99,6 +99,7 @@ asignify_sign_add_file(asignify_sign_t *ctx, const char *f,
 	unsigned char *calc_digest;
 	struct asignify_file check_file;
 	struct asignify_file_digest *dig;
+	bool ret;
 
 	if (ctx == NULL || f == NULL || dt >= ASIGNIFY_DIGEST_MAX) {
 		CTX_MAYBE_SET_ERR(ctx, ASIGNIFY_ERROR_MISUSE);
@@ -111,6 +112,7 @@ asignify_sign_add_file(asignify_sign_t *ctx, const char *f,
 		return (false);
 	}
 
+	ret = false;
 	check_file.fname = xstrdup(f);
 
 	if (dt == ASIGNIFY_DIGEST_SIZE) {
@@ -122,21 +124,23 @@ asignify_sign_add_file(asignify_sign_t *ctx, const char *f,
 		calc_digest = asignify_digest_fd(dt, fd);
 
 		if (calc_digest == NULL) {
-			close(fd);
 			ctx->error = xerr_string(ASIGNIFY_ERROR_SIZE);
-			return (false);
+			goto cleanup;
 		}
+
 		dig = xmalloc0(sizeof(*dig));
 		dig->digest_type = dt;
 		dig->digest = calc_digest;
 		check_file.size = 0;
 		check_file.digests = dig;
-		close(fd);
 	}
 
+	ret = true;
 	kv_push(struct asignify_file, ctx->files, check_file);
+cleanup:
+	close(fd);
 
-	return (true);
+	return (ret);
 }
 
 bool

--- a/libasignify/signature.c
+++ b/libasignify/signature.c
@@ -106,11 +106,6 @@ asignify_signature_load(FILE *f, struct asignify_public_data *pk)
 					pk->id_len, SIG_LEN);
 				break;
 			}
-			else {
-				if (!asignify_sig_try_obsd(buf, r, &res)) {
-					break;
-				}
-			}
 		}
 		if (!asignify_sig_try_obsd(buf, r, &res)) {
 			break;

--- a/libasignify/util.c
+++ b/libasignify/util.c
@@ -51,6 +51,19 @@
 
 #include "asignify_internal.h"
 
+static const unsigned int digest_lens[] = {
+	[ASIGNIFY_DIGEST_SHA512] = SHA512_DIGEST_LENGTH,
+	[ASIGNIFY_DIGEST_SHA256] = SHA256_DIGEST_LENGTH,
+	[ASIGNIFY_DIGEST_BLAKE2] = BLAKE2B_OUTBYTES,
+};
+
+static const char *digest_names[] = {
+	[ASIGNIFY_DIGEST_SHA512] = "SHA512",
+	[ASIGNIFY_DIGEST_SHA256] = "SHA256",
+	[ASIGNIFY_DIGEST_BLAKE2] = "BLAKE2",
+	[ASIGNIFY_DIGEST_SIZE] = "SIZE",
+};
+
 const char* err_str[ASIGNIFY_ERROR_MAX] = {
 	[ASIGNIFY_ERROR_OK] = "no error",
 	[ASIGNIFY_ERROR_FILE] = "file IO error",
@@ -369,28 +382,14 @@ bin2hex(char * const hex, const size_t hex_maxlen,
     return hex;
 }
 
-
 unsigned int
 asignify_digest_len(enum asignify_digest_type type)
 {
-	unsigned int ret;
 
-	switch(type) {
-	case ASIGNIFY_DIGEST_SHA512:
-		ret = SHA512_DIGEST_LENGTH;
-		break;
-	case ASIGNIFY_DIGEST_SHA256:
-		ret = SHA256_DIGEST_LENGTH;
-		break;
-	case ASIGNIFY_DIGEST_BLAKE2:
-		ret = BLAKE2B_OUTBYTES;
-		break;
-	default:
-		ret = 0;
-		break;
+	if (type >= nitems(digest_lens)) {
+		return (0);
 	}
-
-	return (ret);
+	return (digest_lens[type]);
 }
 
 const char *
@@ -398,22 +397,8 @@ asignify_digest_name(enum asignify_digest_type type)
 {
 	const char *ret;
 
-	switch(type) {
-	case ASIGNIFY_DIGEST_SHA512:
-		ret = "SHA512";
-		break;
-	case ASIGNIFY_DIGEST_SHA256:
-		ret = "SHA256";
-		break;
-	case ASIGNIFY_DIGEST_BLAKE2:
-		ret = "BLAKE2";
-		break;
-	case ASIGNIFY_DIGEST_SIZE:
-		ret = "SIZE";
-		break;
-	default:
-		ret = "";
-		break;
+	if (type >= nitems(digest_names) || (ret = digest_names[type]) == NULL) {
+		return ("");
 	}
 
 	return (ret);

--- a/libasignify/verify.c
+++ b/libasignify/verify.c
@@ -376,7 +376,7 @@ bool
 asignify_verify_load_pubkey(asignify_verify_t *ctx, const char *pubf)
 {
 	FILE *f;
-	bool ret = true;
+	bool ret = false;
 	struct asignify_public_data *pk;
 	struct asignify_pubkey_chain *chain;
 
@@ -387,21 +387,23 @@ asignify_verify_load_pubkey(asignify_verify_t *ctx, const char *pubf)
 	f = xfopen(pubf, "r");
 	if (f == NULL) {
 		ctx->error = xerr_string(ASIGNIFY_ERROR_FILE);
+		return (false);
 	}
-	else {
-		pk = asignify_pubkey_load(f);
-		if (pk == NULL) {
-			ctx->error = xerr_string(ASIGNIFY_ERROR_FORMAT);
-			ret = false;
-		}
-		else if (ret) {
-			chain = xmalloc(sizeof(*chain));
-			chain->pk = pk;
-			chain->next = ctx->pk_chain;
-			ctx->pk_chain = chain;
-		}
-		fclose(f);
+
+	pk = asignify_pubkey_load(f);
+	if (pk == NULL) {
+		ctx->error = xerr_string(ASIGNIFY_ERROR_FORMAT);
+		goto cleanup;
 	}
+
+	ret = true;
+	chain = xmalloc(sizeof(*chain));
+	chain->pk = pk;
+	chain->next = ctx->pk_chain;
+	ctx->pk_chain = chain;
+
+cleanup:
+	fclose(f);
 
 	return (ret);
 }

--- a/libasignify/verify.c
+++ b/libasignify/verify.c
@@ -64,6 +64,13 @@ static const struct digest_map_entry {
 	DMAP_ENTRY("size", ASIGNIFY_DIGEST_SIZE),
 };
 
+static const unsigned int digests_sizes[ASIGNIFY_DIGEST_MAX] = {
+	[ASIGNIFY_DIGEST_SHA512] = SHA512_DIGEST_STRING_LENGTH - 1,
+	[ASIGNIFY_DIGEST_SHA256] = SHA256_DIGEST_STRING_LENGTH - 1,
+	[ASIGNIFY_DIGEST_BLAKE2] = BLAKE2B_OUTBYTES * 2,
+	[ASIGNIFY_DIGEST_SIZE] = 0
+};
+
 struct asignify_pubkey_chain {
 	struct asignify_public_data *pk;
 	struct asignify_pubkey_chain *next;
@@ -132,12 +139,6 @@ static bool
 asignify_verify_parse_digest(const char *data, ssize_t dlen,
 	enum asignify_digest_type type, struct asignify_file *f)
 {
-	const unsigned int digests_sizes[ASIGNIFY_DIGEST_MAX] = {
-		[ASIGNIFY_DIGEST_SHA512] = SHA512_DIGEST_STRING_LENGTH - 1,
-		[ASIGNIFY_DIGEST_SHA256] = SHA256_DIGEST_STRING_LENGTH - 1,
-		[ASIGNIFY_DIGEST_BLAKE2] = BLAKE2B_OUTBYTES * 2,
-		[ASIGNIFY_DIGEST_SIZE] = 0
-	};
 	char *errstr;
 	uint64_t flen;
 	struct asignify_file_digest *dig;

--- a/libasignify/verify.c
+++ b/libasignify/verify.c
@@ -550,32 +550,34 @@ asignify_verify_free(asignify_verify_t *ctx)
 	struct asignify_file *f;
 	struct asignify_pubkey_chain *chain, *ctmp;
 
-	if (ctx) {
+	if (ctx == NULL)
+		return;
 
-		chain = ctx->pk_chain;
 
-		while (chain != NULL) {
-			asignify_public_data_free(chain->pk);
-			ctmp = chain;
-			chain = chain->next;
-			free(ctmp);
-		}
-
-		if (ctx->files) {
-			for (k = kh_begin(ctx->files); k != kh_end(ctx->files); ++k) {
-				if (kh_exist(ctx->files, k)) {
-					f = kh_value(ctx->files, k);
-					for(d = f->digests; d && (dtmp = d->next, 1); d = dtmp) {
-						free(d->digest);
-						free(d);
-					}
-					free(f->fname);
-					free(f);
-				}
-			}
-		}
-
-		kh_destroy(asignify_verify_hnode, ctx->files);
-		free(ctx);
+	chain = ctx->pk_chain;
+	while (chain != NULL) {
+		asignify_public_data_free(chain->pk);
+		ctmp = chain;
+		chain = chain->next;
+		free(ctmp);
 	}
+
+	if (ctx->files) {
+		for (k = kh_begin(ctx->files); k != kh_end(ctx->files); ++k) {
+			if (!kh_exist(ctx->files, k))
+				continue;
+			f = kh_value(ctx->files, k);
+
+			for (d = f->digests; d && (dtmp = d->next, 1); d = dtmp) {
+				free(d->digest);
+				free(d);
+			}
+
+			free(f->fname);
+			free(f);
+		}
+	}
+
+	kh_destroy(asignify_verify_hnode, ctx->files);
+	free(ctx);
 }


### PR DESCRIPTION
These are mostly non-functional changes, geared towards providing a clear view of control flow by returning/breaking out early in error cases and reducing mental effort to trace through several levels of branching. I can try to break this out into different chunks, or I can just use it locally to determine what else may need to be done.

That said, there are a couple leaks plugged and more notable changes:
- 05bb65716da6c6a: memory leak
- 2c792c3efdeb591df96252ed6c93f330faee7297: simplified str <-> digest mapping
- 91e50c50543de6d75ff680d068e892d0c5455821: reworked digest parser, it's perhaps a little more strict but in theory the changed bits shouldn't get hit because the digest is signed and intact...
- 9b921a9d009a827574bf1bf91162b8fa6e4e8545: fd leak
- 7f424d51ea2e22c0d345dd0a7a6bc6e6454ce80d: memory and fd leak
- 6bc2f0f9dd44ff48e6aa268c51116e843b943263: reinterpret rounds == 0 to mean "no encryption", enforce either rounds == 0 || rounds >= minrounds[*]
- 72d90764455c775e0f0729525ecbdcda112b52d8: memory leak
- 38c82ffa7fe0b5bfe6ceb30ae6489fdecee20bd0: unrolled some file processing loop by one to handle headers up-front and simplify the file processing

[*] Specifically, password_cb will be ignored for rounds == 0 so that callers can simplify a little by always passing a password_cb that simply won't be used. While this could be argued as less safe, the caller has to sanity check what they're passing anyways.