### PR TITLE
cmake: chop off the lib prefix of libasignify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library(libasignify
         libasignify/tweetnacl.h
         libasignify/util.c
         libasignify/verify.c)
+set_target_properties(libasignify
+        PROPERTIES PREFIX "")
 
 add_executable(asignify
         src/asignify.c


### PR DESCRIPTION
add_library() targets will have 'lib' prepended, so we end up with a
liblibasignify.  We can't use the "correct" target name for the lib, so
just unset the prefix to end up with libasignify.