### PR TITLE
libasignify: add a version script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 set(CMAKE_C_STANDARD 11)
 
@@ -92,6 +92,8 @@ add_library(libasignify
         libasignify/tweetnacl.h
         libasignify/util.c
         libasignify/verify.c)
+target_link_options(libasignify
+        PUBLIC "LINKER:--version-script=${CMAKE_SOURCE_DIR}/libasignify/libasignify.ver")
 
 add_executable(asignify
         src/asignify.c

--- a/libasignify/libasignify.ver
+++ b/libasignify/libasignify.ver
@@ -1,0 +1,42 @@
+LIBASIGNIFY_1.0 {
+global:
+	asignify_verify_init;
+	asignify_verify_load_pubkey;
+	asignify_verify_load_signature;
+	asignify_verify_file;
+	asignify_verify_get_error;
+	asignify_verify_free;
+
+	asignify_sign_init;
+	asignify_sign_load_privkey;
+	asignify_sign_add_file;
+	asignify_sign_write_signature;
+	asignify_sign_get_error;
+	asignify_sign_free;
+
+	asignify_generate;
+	asignify_generate_pubkey;
+
+	explicit_memzero;
+
+	asignify_digest_len;
+	asignify_digest_name;
+	asignify_digest_fd;
+	asignify_digest_from_str;
+
+	asignify_privkey_from_ssh;
+
+	asignify_encrypt_init;
+	asignify_encrypt_load_pubkey;
+	asignify_encrypt_load_privkey;
+	asignify_encrypt_crypt_file;
+	asignify_encrypt_decrypt_file;
+	asignify_encrypt_get_error;
+	asignify_encrypt_free;
+
+	# CSU symbols, sigh.
+	__progname;
+	environ;
+local:
+	*;
+};


### PR DESCRIPTION
Some impending changes to be more friendly for FreeBSD's pkg (and other
applications) are going to break ABI for a large chunk of libasignify
by changing filename arguments to FILEs and adding name arguments in
some places.

Prepare in advance by adding a versioning script while we have the
old version in place, so we can at least offer binary compatibility
going forward.